### PR TITLE
Updated the Realtime JavaScript CDN link

### DIFF
--- a/web/connect.html
+++ b/web/connect.html
@@ -22,7 +22,7 @@
 
 		<script src="js/libs/stats.min.js"></script>
 		
-		<script src="http://dfdbz2tdq3k01.cloudfront.net/js/2.1.0/ortc.js"></script>
+		<script src="http://messaging-public.realtime.co/js/2.1.0/ortc.js"></script>
 		
 
 		<script>

--- a/web/master_cube_client.html
+++ b/web/master_cube_client.html
@@ -22,7 +22,7 @@
 
 		<script src="js/libs/stats.min.js"></script>
 		
-		<script src="http://dfdbz2tdq3k01.cloudfront.net/js/2.1.0/ortc.js"></script>
+		<script src="http://messaging-public.realtime.co/js/2.1.0/ortc.js"></script>
 		
 
 		<script>

--- a/web/master_cube_old.html
+++ b/web/master_cube_old.html
@@ -22,7 +22,7 @@
 
 		<script src="js/libs/stats.min.js"></script>
 		
-		<script src="http://dfdbz2tdq3k01.cloudfront.net/js/2.1.0/ortc.js"></script>
+		<script src="http://messaging-public.realtime.co/js/2.1.0/ortc.js"></script>
 		
 
 		<script>


### PR DESCRIPTION
The cloudfront url is deprecated and will stop working in the future.
